### PR TITLE
Adjust test run date container size

### DIFF
--- a/src/components/LiveTestAutomation.tsx
+++ b/src/components/LiveTestAutomation.tsx
@@ -255,7 +255,7 @@ const DateBadge = styled(StatItem)`
     width: 260px;
     font-variant-numeric: tabular-nums;
     @media (max-width: 768px) {
-        width: 220px;
+        width: 260px;
     }
 `;
 


### PR DESCRIPTION
Increase `DateBadge` width on mobile to prevent date text truncation on the Live Automation page.

---
[Slack Thread](https://t-start.slack.com/archives/D092PCQD9FH/p1754724868836949?thread_ts=1754724868.836949&cid=D092PCQD9FH)

<a href="https://cursor.com/background-agent?bcId=bc-2013ea41-4a0c-48dc-b33a-cd63b77426fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2013ea41-4a0c-48dc-b33a-cd63b77426fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

